### PR TITLE
Remove bug `Method 'map' cannot be called on 'List<XFile>?' because it is potentially null`

### DIFF
--- a/lib/image_editor_plus.dart
+++ b/lib/image_editor_plus.dart
@@ -159,9 +159,9 @@ class _MultiImageEditorState extends State<MultiImageEditor> {
             if (images.length < widget.maxLength && widget.allowGallery)
               IconButton(
                 icon: const Icon(Icons.photo),
-                onPressed: () async {
-                  var selected = await picker.pickMultiImage();
-
+                 onPressed: () async {
+                  List<XFile>? selected = await picker.pickMultiImage();
+                  if (selected == null) return;
                   images.addAll(selected.map((e) => ImageItem(e)).toList());
                 },
               ).paddingSymmetric(horizontal: 8),


### PR DESCRIPTION
In Dart 2.18.0 I found this bug in the app build time.

Bug: 

```
/C:/flutter/.pub-cache/hosted/pub.dartlang.org/image_editor_plus-0.1.8/lib/image_editor_plus.dart:165:42: Error: Method 'map' cannot be called on 'List<XFile>?' because it is potentially null.
 - 'List' is from 'dart:core'.
- 'XFile' is from 'package:cross_file/src/types/io.dart' ('/C:/flutter/.pub-cache/hosted/pub.dartlang.org/cross_file-0.3.3+1/lib/src/types/io.dart').
package:cross_file/…/types/io.dart:1
Try calling using ?. instead.
                  images.addAll(selected.map((e) => ImageItem(e)).toList());
                                         ^^^
3

FAILURE: Build failed with an exception.

* Where:
Script 'C:\flutter\packages\flutter_tools\gradle\flutter.gradle' line: 1159

* What went wrong:
Execution failed for task ':app:compileFlutterBuildSprodDebug'.
> Process 'command 'C:\flutter\bin\flutter.bat'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 43s
Exception: Gradle task assembleSprodDebug failed with exit code 1
```