### PR TITLE
Update image_editor_plus.dart

### DIFF
--- a/lib/image_editor_plus.dart
+++ b/lib/image_editor_plus.dart
@@ -193,7 +193,6 @@ class _MultiImageEditorState extends State<MultiImageEditor> {
     return Theme(
       data: ImageEditor.theme,
       child: Scaffold(
-        key: scaffoldGlobalKey,
         appBar: AppBar(
           automaticallyImplyLeading: false,
           actions: [


### PR DESCRIPTION
This global key breaks the plugin. Works with it removed.