### PR TITLE
Bump image library to fix vulunarbilities

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   image_picker: ^1.0.0
   screenshot: ^3.0.0
   extended_image: ^8.1.0
-  image: ^4.0.15
+  image: ^4.3.1
   colorfilter_generator: ^0.0.8
   hand_signature: ^3.0.0
   reorderables: ^0.6.0


### PR DESCRIPTION
CVE,CVSS score,CVSS severity,Package name,Installed version,Patched version,Published date,Fix available,Non OS packages
CVE-2023-39139,7.8,,archive,3.3.7,3.3.8,2023-08-30,Yes,./pubspec.lock
CVE-2023-39137,7.8,,archive,3.3.7,3.3.8,2023-08-30,Yes,./pubspec.lock